### PR TITLE
Handle `BIGINT` column types with floating exponents

### DIFF
--- a/resultset_rows.go
+++ b/resultset_rows.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"math/big"
 	"reflect"
 	"strconv"
 	"strings"
@@ -179,8 +180,13 @@ func (r *resultSetRows) Next(dest []driver.Value) error {
 			fallthrough
 		case strings.HasPrefix(col.Type, "VARCHAR") || strings.HasPrefix(col.Type, "ARRAY") || strings.HasPrefix(col.Type, "MAP") || strings.HasPrefix(col.Type, "STRUCT"):
 			dest[idx] = *rowData[idx]
-		case col.Type == "TINYINT" || col.Type == "SMALLINT" || col.Type == "INTEGER" || col.Type == "BIGINT":
+		case col.Type == "TINYINT" || col.Type == "SMALLINT" || col.Type == "INTEGER":
 			dest[idx], err = strconv.ParseInt(*rowData[idx], 10, 64)
+			if err != nil {
+				return err
+			}
+		case col.Type == "BIGINT":
+			dest[idx], _, err = big.ParseFloat(*rowData[idx], 10, 0, big.ToNearestEven)
 			if err != nil {
 				return err
 			}

--- a/resultset_rows.go
+++ b/resultset_rows.go
@@ -186,10 +186,11 @@ func (r *resultSetRows) Next(dest []driver.Value) error {
 				return err
 			}
 		case col.Type == "BIGINT":
-			dest[idx], _, err = big.ParseFloat(*rowData[idx], 10, 0, big.ToNearestEven)
+			flt, _, err := big.ParseFloat(*rowData[idx], 10, 0, big.ToNearestEven)
 			if err != nil {
 				return err
 			}
+			dest[idx], _ = flt.Int(new(big.Int))
 		case col.Type == "FLOAT" || col.Type == "DOUBLE" || strings.HasPrefix(col.Type, "DECIMAL"):
 			dest[idx], err = strconv.ParseFloat(*rowData[idx], 64)
 			if err != nil {

--- a/streaming_rows.go
+++ b/streaming_rows.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -339,8 +340,13 @@ func (r *streamingRows) Next(dest []driver.Value) error {
 			fallthrough
 		case strings.HasPrefix(col.Type, "VARCHAR") || strings.HasPrefix(col.Type, "ARRAY") || strings.HasPrefix(col.Type, "MAP") || strings.HasPrefix(col.Type, "STRUCT"):
 			dest[idx] = *rowData.Data[idx]
-		case col.Type == "TINYINT" || col.Type == "SMALLINT" || col.Type == "INTEGER" || col.Type == "BIGINT":
+		case col.Type == "TINYINT" || col.Type == "SMALLINT" || col.Type == "INTEGER":
 			dest[idx], err = strconv.ParseInt(*rowData.Data[idx], 10, 64)
+			if err != nil {
+				return err
+			}
+		case col.Type == "BIGINT":
+			dest[idx], _, err = big.ParseFloat(*rowData.Data[idx], 10, 0, big.ToNearestEven)
 			if err != nil {
 				return err
 			}

--- a/streaming_rows.go
+++ b/streaming_rows.go
@@ -346,10 +346,11 @@ func (r *streamingRows) Next(dest []driver.Value) error {
 				return err
 			}
 		case col.Type == "BIGINT":
-			dest[idx], _, err = big.ParseFloat(*rowData.Data[idx], 10, 0, big.ToNearestEven)
+			flt, _, err := big.ParseFloat(*rowData.Data[idx], 10, 0, big.ToNearestEven)
 			if err != nil {
 				return err
 			}
+			dest[idx], _ = flt.Int(new(big.Int))
 		case col.Type == "FLOAT" || col.Type == "DOUBLE" || strings.HasPrefix(col.Type, "DECIMAL"):
 			dest[idx], err = strconv.ParseFloat(*rowData.Data[idx], 64)
 			if err != nil {


### PR DESCRIPTION
Use `math/big` to convert big integers, e.g. `"1.716938948105e+12"`, to their integer representation for the rows, and get around the limitation with `strconv`. This handles big integers with or without exponent.