### PR TITLE
check for expected data

### DIFF
--- a/streaming_rows.go
+++ b/streaming_rows.go
@@ -222,14 +222,19 @@ func (r *streamingRows) readMessages() {
 						continue
 					}
 					d := *describe.Data
-					for i, col := range describe.Metadata.Columns {
-						if strings.ToLower(col.Name) == "state" && strings.ToLower(*d[0][i]) == "errored" {
-							errd = true
-							continue
-						}
-						if strings.ToLower(col.Name) == "messages" {
-							msg = fmt.Sprintf("%s\n\n%s", *d[0][i], message)
-							continue
+					if len(d) > 0 {
+						for i, col := range describe.Metadata.Columns {
+							if i > len(d[0]) {
+								continue
+							}
+							if strings.ToLower(col.Name) == "state" && strings.ToLower(*d[0][i]) == "errored" {
+								errd = true
+								continue
+							}
+							if strings.ToLower(col.Name) == "messages" {
+								msg = fmt.Sprintf("%s\n\n%s", *d[0][i], message)
+								continue
+							}
 						}
 					}
 					if errd {


### PR DESCRIPTION
fix for
```
		goroutine 9 [running]:
		github.com/deltastreaminc/go-deltastream.(*streamingRows).readMessages(0xc0000c0320)
			/home/runner/go/pkg/mod/github.com/deltastreaminc/go-deltastream@v0.0.0-20240802155751-5d6e49d410da/streaming_rows.go:226 +0x74f
		created by github.com/deltastreaminc/go-deltastream.newStreamingRows in goroutine 1
			/home/runner/go/pkg/mod/github.com/deltastreaminc/go-deltastream@v0.0.0-20240802155751-5d6e49d410da/streaming_rows.go:190 +0x646
```