### PR TITLE
Use server parsing for `DATE` to avoid lost context with `time.Time`

### DIFF
--- a/datatype_test.go
+++ b/datatype_test.go
@@ -25,12 +25,11 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
 
 func TestDatatypes(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -106,7 +105,7 @@ func TestDatatypes(t *testing.T) {
 		decimal                float64
 		timestamp              time.Time
 		timestamp_tz           time.Time
-		date                   time.Time
+		date                   string
 		timev                  time.Time
 		timestamp_ltz          time.Time
 		varbinary              []byte
@@ -125,7 +124,7 @@ func TestDatatypes(t *testing.T) {
 		decimal_nullable       *float64
 		timestamp_nullable     *time.Time
 		timestamp_tz_nullable  *time.Time
-		date_nullable          *time.Time
+		date_nullable          *string
 		time_nullable          *time.Time
 		timestamp_ltz_nullable *time.Time
 		varbinary_nullable     *[]byte

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -60,7 +60,6 @@ func TestDatatypes(t *testing.T) {
 		"DOUBLE",
 		"DECIMAL",
 		"TIMESTAMP",
-		"TIMESTAMP_TZ",
 		"DATE",
 		"TIME",
 		"TIMESTAMP_LTZ",
@@ -79,7 +78,6 @@ func TestDatatypes(t *testing.T) {
 		"DOUBLE_NULLABLE",
 		"DECIMAL_NULLABLE",
 		"TIMESTAMP_NULLABLE",
-		"TIMESTAMP_TZ_NULLABLE",
 		"DATE_NULLABLE",
 		"TIME_NULLABLE",
 		"TIMESTAMP_LTZ_NULLABLE",
@@ -104,7 +102,6 @@ func TestDatatypes(t *testing.T) {
 		doublev                float64
 		decimal                float64
 		timestamp              time.Time
-		timestamp_tz           time.Time
 		date                   string
 		timev                  time.Time
 		timestamp_ltz          time.Time
@@ -123,7 +120,6 @@ func TestDatatypes(t *testing.T) {
 		double_nullable        *float64
 		decimal_nullable       *float64
 		timestamp_nullable     *time.Time
-		timestamp_tz_nullable  *time.Time
 		date_nullable          *string
 		time_nullable          *time.Time
 		timestamp_ltz_nullable *time.Time
@@ -145,7 +141,6 @@ func TestDatatypes(t *testing.T) {
 			&doublev,
 			&decimal,
 			&timestamp,
-			&timestamp_tz,
 			&date,
 			&timev,
 			&timestamp_ltz,
@@ -164,7 +159,6 @@ func TestDatatypes(t *testing.T) {
 			&double_nullable,
 			&decimal_nullable,
 			&timestamp_nullable,
-			&timestamp_tz_nullable,
 			&date_nullable,
 			&time_nullable,
 			&timestamp_ltz_nullable,

--- a/fixtures/list-organizations-200-00000-0.json
+++ b/fixtures/list-organizations-200-00000-0.json
@@ -10,7 +10,7 @@
             {"name": "name", "type": "VARCHAR", "nullable": false},
             {"name": "description", "type": "VARCHAR", "nullable": true},
             {"name": "profileImageURI", "type": "VARCHAR", "nullable": true},
-            {"name": "createdAt", "type": "TIMESTAMP_TZ", "nullable": false}
+            {"name": "createdAt", "type": "TIMESTAMP_LTZ", "nullable": false}
         ],
         "context": {}
     },

--- a/fixtures/list-organizations-200-00000-1.json
+++ b/fixtures/list-organizations-200-00000-1.json
@@ -10,7 +10,7 @@
             {"name": "name", "type": "VARCHAR", "nullable": false},
             {"name": "description", "type": "VARCHAR", "nullable": true},
             {"name": "profileImageURI", "type": "VARCHAR", "nullable": true, "display_hint": "nowrap"},
-            {"name": "createdAt", "type": "TIMESTAMP_TZ", "nullable": false}
+            {"name": "createdAt", "type": "TIMESTAMP_LTZ", "nullable": false}
         ],
         "context": {}
     },

--- a/fixtures/test-datatypes-200-00000-4.json
+++ b/fixtures/test-datatypes-200-00000-4.json
@@ -15,7 +15,6 @@
             {"name": "DOUBLE", "type": "DOUBLE", "nullable": false},
             {"name": "DECIMAL", "type": "DECIMAL(4, 3)", "nullable": false},
             {"name": "TIMESTAMP", "type": "TIMESTAMP(3)", "nullable": false},
-            {"name": "TIMESTAMP_TZ", "type": "TIMESTAMP_TZ", "nullable": false},
             {"name": "DATE", "type": "DATE", "nullable": false},
             {"name": "TIME", "type": "TIME", "nullable": false},
             {"name": "TIMESTAMP_LTZ", "type": "TIMESTAMP_LTZ", "nullable": false},
@@ -34,7 +33,6 @@
             {"name": "DOUBLE_NULLABLE", "type": "DOUBLE", "nullable": true},
             {"name": "DECIMAL_NULLABLE", "type": "DECIMAL(4, 3)", "nullable": true},
             {"name": "TIMESTAMP_NULLABLE", "type": "TIMESTAMP(3)", "nullable": true},
-            {"name": "TIMESTAMP_TZ_NULLABLE", "type": "TIMESTAMP_TZ", "nullable": true},
             {"name": "DATE_NULLABLE", "type": "DATE", "nullable": true},
             {"name": "TIME_NULLABLE", "type": "TIME", "nullable": true},
             {"name": "TIMESTAMP_LTZ_NULLABLE", "type": "TIMESTAMP_LTZ", "nullable": true},
@@ -48,9 +46,9 @@
         "context": {}
     },
     "data": [
-        ["VARCHAR", "127", "32767", "2147483647", "9223372036854775807", "-1.79E+308", "-1.79E+308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "true", "VARCHAR", "127", "32767", "2147483647", "9223372036854775807", "-1.79E+308", "-1.79E+308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "true"],
-        ["VARCHAR", "0", "-32768", "-2147483648", "-9223372036854775808", "-2.23E-308", "-2.23E-308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30 13:10:02.0474381+0800", "2007-04-30", "13:10:02.0474381Z", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "false", null, null, null, null,null, null, null, null, null,null, null, null, null, null, null, null, null, null, null],
-        ["VARCHAR", "0", "-32768", "-2147483648", "-9223372036854775808", "2.23E-308", "2.23E-308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30 13:10:02.0474381-0700", "2007-04-30", "13:10:02.0474381Z", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "false", null, null, null, null,null, null, null, null, null,null, null, null, null, null, null, null, null, null, null],
-        ["VARCHAR", "0", "-32768", "-2147483648", "-9223372036854775808", "1.79E+308", "1.79E+308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "2007-04-30", "13:10:02.0474381Z", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "false", null, null, null, null,null, null, null, null, null,null, null, null, null, null, null, null, null, null, null]
+        ["VARCHAR", "127", "32767", "2147483647", "9223372036854775807", "-1.79E+308", "-1.79E+308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "true", "VARCHAR", "127", "32767", "2147483647", "9223372036854775807", "-1.79E+308", "-1.79E+308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "true"],
+        ["VARCHAR", "0", "-32768", "-2147483648", "-9223372036854775808", "-2.23E-308", "-2.23E-308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "false", null, null, null, null,null, null, null, null, null, null, null, null, null, null, null, null, null, null],
+        ["VARCHAR", "0", "-32768", "-2147483648", "-9223372036854775808", "2.23E-308", "2.23E-308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "false", null, null, null, null,null, null, null, null, null, null, null, null, null, null, null, null, null, null],
+        ["VARCHAR", "0", "-32768", "-2147483648", "-9223372036854775808", "1.79E+308", "1.79E+308", "123.00", "2007-04-30 13:10:02.0474381", "2007-04-30", "13:10:02.0474381", "2007-04-30 13:10:02.0474381Z", "YmluYXJ5", "YmluYXJ5", "[1,2,3,4]", "{\"k\": \"v\"}", "{\"k\": \"v\"}", "false", null, null, null, null,null, null, null, null, null, null, null, null, null, null, null, null, null, null]
     ]
 }

--- a/query_test.go
+++ b/query_test.go
@@ -162,7 +162,7 @@ func TestSimpleResultset(t *testing.T) {
 		&ColumnMatcher{Name: "name", DatabaseType: "VARCHAR"},
 		&ColumnMatcher{Name: "description", DatabaseType: "VARCHAR"},
 		&ColumnMatcher{Name: "profileImageURI", DatabaseType: "VARCHAR"},
-		&ColumnMatcher{Name: "createdAt", DatabaseType: "TIMESTAMP_TZ"},
+		&ColumnMatcher{Name: "createdAt", DatabaseType: "TIMESTAMP_LTZ"},
 	))
 
 	var (
@@ -213,7 +213,7 @@ func TestSimpleResultsetWithDisplayHints(t *testing.T) {
 		&ColumnMatcher{Name: "name", DatabaseType: "VARCHAR"},
 		&ColumnMatcher{Name: "description", DatabaseType: "VARCHAR"},
 		&ColumnMatcher{Name: "profileImageURI", DatabaseType: "VARCHAR;nowrap"},
-		&ColumnMatcher{Name: "createdAt", DatabaseType: "TIMESTAMP_TZ"},
+		&ColumnMatcher{Name: "createdAt", DatabaseType: "TIMESTAMP_LTZ"},
 	))
 }
 

--- a/resultset_rows.go
+++ b/resultset_rows.go
@@ -185,9 +185,17 @@ func (r *resultSetRows) Next(dest []driver.Value) error {
 			dest[idx] = nil
 		default:
 			fallthrough
-		case strings.HasPrefix(col.Type, "VARCHAR") || strings.HasPrefix(col.Type, "ARRAY") || strings.HasPrefix(col.Type, "MAP") || strings.HasPrefix(col.Type, "STRUCT"):
+		case // as parsed by the server
+			strings.HasPrefix(col.Type, "VARCHAR"),
+			col.Type == "DATE",
+			strings.HasPrefix(col.Type, "ARRAY"),
+			strings.HasPrefix(col.Type, "MAP"),
+			strings.HasPrefix(col.Type, "STRUCT"):
 			dest[idx] = *rowData[idx]
-		case col.Type == "TINYINT" || col.Type == "SMALLINT" || col.Type == "INTEGER":
+		case
+			col.Type == "TINYINT",
+			col.Type == "SMALLINT",
+			col.Type == "INTEGER":
 			dest[idx], err = strconv.ParseInt(*rowData[idx], 10, 64)
 			if err != nil {
 				return err
@@ -198,17 +206,22 @@ func (r *resultSetRows) Next(dest []driver.Value) error {
 				return err
 			}
 			dest[idx], _ = flt.Int(new(big.Int))
-		case col.Type == "FLOAT" || col.Type == "DOUBLE" || strings.HasPrefix(col.Type, "DECIMAL"):
+		case
+			col.Type == "FLOAT",
+			col.Type == "DOUBLE",
+			strings.HasPrefix(col.Type, "DECIMAL"):
 			dest[idx], err = strconv.ParseFloat(*rowData[idx], 64)
 			if err != nil {
 				return err
 			}
-		case strings.HasPrefix(col.Type, "TIME") || col.Type == "DATE":
+		case strings.HasPrefix(col.Type, "TIME"):
 			dest[idx], err = parseTime(*rowData[idx], col.Type)
 			if err != nil {
 				return err
 			}
-		case col.Type == "VARBINARY" || col.Type == "BYTES":
+		case
+			col.Type == "VARBINARY",
+			col.Type == "BYTES":
 			dest[idx], err = base64.StdEncoding.DecodeString(*rowData[idx])
 			if err != nil {
 				return err

--- a/resultset_rows.go
+++ b/resultset_rows.go
@@ -56,7 +56,6 @@ func init() {
 		"DOUBLE":        reflect.TypeOf(float64(0)),
 		"DECIMAL":       reflect.TypeOf(float64(0)),
 		"TIMESTAMP":     reflect.TypeOf(time.Now()),
-		"TIMESTAMP_TZ":  reflect.TypeOf(time.Now()),
 		"DATE":          reflect.TypeOf(time.Now()),
 		"TIME":          reflect.TypeOf(time.Now()),
 		"TIMESTAMP_LTZ": reflect.TypeOf(time.Now()),
@@ -249,10 +248,13 @@ func parseTime(s, colType string) (time.Time, error) {
 	}
 
 	switch {
-	case strings.HasPrefix(colType, `TIMESTAMP`):
+	case
+		strings.HasSuffix(colType, `WITH LOCAL TIME ZONE`),
+		strings.HasPrefix(colType, `TIMESTAMP_LTZ`):
+
 		sspl := strings.Split(s, " ")
 		if len(sspl) != 2 {
-			return time.Now(), fmt.Errorf("invalid timestamp")
+			return time.Now(), fmt.Errorf("invalid timestamp_ltz %s", s)
 		}
 		timePart := sspl[1]
 		containsNano := strings.Contains(timePart, ".")
@@ -266,18 +268,38 @@ func parseTime(s, colType string) (time.Time, error) {
 			layout += "Z0700"
 		}
 		return time.Parse(layout, s)
-	case colType == `TIME` || strings.HasPrefix(colType, "TIME("):
+	case
+		colType == `TIMESTAMP`,
+		strings.HasPrefix(colType, `TIMESTAMP(`):
+
+		sspl := strings.Split(s, " ")
+		if len(sspl) != 2 {
+			return time.Now(), fmt.Errorf("invalid timestamp %s", s)
+		}
+		timePart := sspl[1]
+		containsNano := strings.Contains(timePart, ".")
+		if strings.Contains(timePart, "Z") || strings.Contains(timePart, "+") || strings.Contains(timePart, "-") {
+			return time.Now(), fmt.Errorf("timestamp cannot be parsed with timezone. timestamp_ltz must be used instead")
+		}
+		layout := "2006-01-02 15:04:05"
+		if containsNano {
+			layout += ".999999999"
+		}
+		return time.Parse(layout, s)
+	case
+		colType == `TIME`,
+		strings.HasPrefix(colType, "TIME("):
+
 		containsNano := strings.Contains(s, ".")
-		containsTZ := strings.Contains(s, "Z") || strings.Contains(s, "+") || strings.Contains(s, "-")
+		if strings.Contains(s, "Z") || strings.Contains(s, "+") || strings.Contains(s, "-") {
+			return time.Now(), fmt.Errorf("time cannot be parsed with timezone")
+		}
 		layout := "15:04:05"
 		if containsNano {
 			layout += ".999999999"
 		}
-		if containsTZ {
-			layout += "Z0700"
-		}
 		return time.Parse(layout, s)
 	default:
-		return time.Now(), fmt.Errorf("unsupported column type")
+		return time.Now(), fmt.Errorf("unsupported column type %s", colType)
 	}
 }

--- a/streaming_rows.go
+++ b/streaming_rows.go
@@ -383,9 +383,17 @@ func (r *streamingRows) Next(dest []driver.Value) error {
 			dest[idx] = nil
 		default:
 			fallthrough
-		case strings.HasPrefix(col.Type, "VARCHAR") || strings.HasPrefix(col.Type, "ARRAY") || strings.HasPrefix(col.Type, "MAP") || strings.HasPrefix(col.Type, "STRUCT"):
+		case // as parsed by the server
+			strings.HasPrefix(col.Type, "VARCHAR"),
+			col.Type == "DATE",
+			strings.HasPrefix(col.Type, "ARRAY"),
+			strings.HasPrefix(col.Type, "MAP"),
+			strings.HasPrefix(col.Type, "STRUCT"):
 			dest[idx] = *rowData.Data[idx]
-		case col.Type == "TINYINT" || col.Type == "SMALLINT" || col.Type == "INTEGER":
+		case
+			col.Type == "TINYINT",
+			col.Type == "SMALLINT",
+			col.Type == "INTEGER":
 			dest[idx], err = strconv.ParseInt(*rowData.Data[idx], 10, 64)
 			if err != nil {
 				return err
@@ -396,17 +404,22 @@ func (r *streamingRows) Next(dest []driver.Value) error {
 				return err
 			}
 			dest[idx], _ = flt.Int(new(big.Int))
-		case col.Type == "FLOAT" || col.Type == "DOUBLE" || strings.HasPrefix(col.Type, "DECIMAL"):
+		case
+			col.Type == "FLOAT",
+			col.Type == "DOUBLE",
+			strings.HasPrefix(col.Type, "DECIMAL"):
 			dest[idx], err = strconv.ParseFloat(*rowData.Data[idx], 64)
 			if err != nil {
 				return err
 			}
-		case strings.HasPrefix(col.Type, "TIME") || col.Type == "DATE":
+		case strings.HasPrefix(col.Type, "TIME"):
 			dest[idx], err = parseTime(*rowData.Data[idx], col.Type)
 			if err != nil {
 				return err
 			}
-		case col.Type == "VARBINARY" || col.Type == "BYTES":
+		case
+			col.Type == "VARBINARY",
+			col.Type == "BYTES":
 			dest[idx], err = base64.StdEncoding.DecodeString(*rowData.Data[idx])
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently `DATE` and `TIME` are being parsed on the driver side to a `time.Time` where time information is re-added back to the date portion of a `DATE` column, e.g. `2024-08-07 00:00:00Z` where it should be provided as `2024-08-07`.

This change ensures that date formatting is retained as decided by the server, and all other timestamps are converted to the appropriate format using the `time.Time` interface.