### PR TITLE
Append requestID onto sql error messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -85,5 +85,9 @@ type ErrSQLError struct {
 }
 
 func (e ErrSQLError) Error() string {
-	return fmt.Sprintf("sql error: %s", e.Message)
+	var sid string
+	if e.StatementID != uuid.Nil {
+		sid = fmt.Sprintf(" RequestID: %s", e.StatementID.String())
+	}
+	return fmt.Sprintf("sql error: %s%s", e.Message, sid)
 }


### PR DESCRIPTION
```mydb.public/mystore# CREATE DATABASE;
sql error: parse error: line 1:15 no viable alternative at input ';' (SQLState: 42601) RequestID: 5dc1963c-4275-41b7-bec3-737cc06e15bb
```