### PR TITLE
Add sqlcode to streaming error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -85,5 +85,5 @@ type ErrSQLError struct {
 }
 
 func (e ErrSQLError) Error() string {
-	return fmt.Sprintf("sql error: %s", e.Message)
+	return fmt.Sprintf("sql error: %s (SQLState: %s)", e.Message, e.SQLCode)
 }


### PR DESCRIPTION
I ran into a bug where we were printing the sqlcode in an error `Error: sql error: invalid token`